### PR TITLE
[Feature] Add documentation and comments for Axios max upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,26 @@ To run:
 node upload-file.js
 ```
 
+**For large file**
+
+`Axios` have a default request body size of **2000 bytes**. To change that, simply modify `maxBodyLength` in the configuration as one of the `Axios` request function arguments like this:
+
+```js
+var config = {
+  method: 'post',
+  url: 'https://api-us.musiio.com/v1/search/upload/file',
+  auth: {
+    username: API_KEY,
+    password: ""
+  },
+  headers: { 
+    ...data.getHeaders()
+  },
+  data : data,
+  maxBodyLength: 10000 // specify the request body length here!
+};
+```
+
 ### Upload YouTube Link
 
 `upload-youtube-link.js`

--- a/samples/node/upload-file.js
+++ b/samples/node/upload-file.js
@@ -17,7 +17,8 @@ var config = {
   headers: { 
     ...data.getHeaders()
   },
-  data : data
+  data : data,
+  maxBodyLength: 2000 // Change the maximum body length in bytes allowable for the request if you want to upload larger file
 };
 
 axios(config)


### PR DESCRIPTION
Same as Tagging, added documentation and comments about the Node.js Axios library change default max request body length in bytes.